### PR TITLE
Fix nil evidence content

### DIFF
--- a/lib/dradis/plugins/nexpose/formats/full.rb
+++ b/lib/dradis/plugins/nexpose/formats/full.rb
@@ -57,6 +57,8 @@ module Dradis::Plugins::Nexpose::Formats
           if xml_vuln.xpath("./hosts/host[text()='#{nexpose_node.address}']").empty?
             xml_vuln.last_element_child.add_child( "<host>#{nexpose_node.address}</host>")
           end
+
+          evidence[test_id][nexpose_node.address] = node_test[:content]
         end
 
         nexpose_node.endpoints.each do |endpoint|
@@ -141,7 +143,7 @@ module Dradis::Plugins::Nexpose::Formats
             # if the node exists, this just returns it
             host_node = content_service.create_node(label: host_name, type: :host)
 
-            evidence_content = evidence[id][host_name] || "n/a"
+            evidence_content = evidence[id][host_name]
             content_service.create_evidence(content: evidence_content, issue: issue, node: host_node)
           end
 

--- a/lib/dradis/plugins/nexpose/formats/full.rb
+++ b/lib/dradis/plugins/nexpose/formats/full.rb
@@ -141,7 +141,7 @@ module Dradis::Plugins::Nexpose::Formats
             # if the node exists, this just returns it
             host_node = content_service.create_node(label: host_name, type: :host)
 
-            evidence_content = evidence[id][host_name]
+            evidence_content = evidence[id][host_name] || "n/a"
             content_service.create_evidence(content: evidence_content, issue: issue, node: host_node)
           end
 


### PR DESCRIPTION
### Spec

Currently, the NeXpose plugin can create Evidences with `nil` content. This can create problems with exporting such as:
```
[NoMethodError] undefined method `gsub' for nil:NilClass
```

#### Proposed Solution:
Catch the `nil` content for Evidences and use "n/a" instead.


### How to test

1. Create a blank project
2. Go to "Upload output from tool in the app" in Dradis Pro
3. Upload the attached XML using the Nexpose plugin
4. Export the project as a Package or a Template
5. Assert that there were no raised errors when exporting.