### PR TITLE
Wrap ciphers in code blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Dradis Framework 3.14 (XXX, 2019) ##
+
+*   Wrap ciphers in code blocks
+
 ## Dradis Framework 3.13 (June, 2019) ##
 
 *   No changes.

--- a/lib/dradis/plugins/nexpose/gem_version.rb
+++ b/lib/dradis/plugins/nexpose/gem_version.rb
@@ -8,7 +8,7 @@ module Dradis
 
       module VERSION
         MAJOR = 3
-        MINOR = 14
+        MINOR = 15
         TINY = 0
         PRE = 'rc1'
 

--- a/lib/dradis/plugins/nexpose/gem_version.rb
+++ b/lib/dradis/plugins/nexpose/gem_version.rb
@@ -8,9 +8,9 @@ module Dradis
 
       module VERSION
         MAJOR = 3
-        MINOR = 13
+        MINOR = 14
         TINY = 0
-        PRE = nil
+        PRE = 'rc1'
 
         STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")
       end

--- a/lib/nexpose/vulnerability.rb
+++ b/lib/nexpose/vulnerability.rb
@@ -8,6 +8,8 @@ module Nexpose
   # Instead of providing separate methods for each supported property we rely
   # on Ruby's #method_missing to do most of the work.
   class Vulnerability
+    SSL_CIPHER_VULN_IDS = %w[ssl].freeze
+
     # Accepts an XML node from Nokogiri::XML.
     def initialize(xml_node)
       @xml = xml_node
@@ -77,9 +79,7 @@ module Nexpose
       # We need to clean up tags that have HTML content in them
       if tags_with_html_content.include?(method)
         result = cleanup_html(tag)
-        if @xml.attributes['id'].value.include? "ssl"
-          result = add_bc_to_ciphers(result)
-        end
+        result = add_bc_to_ssl_cipher_list(result) if SSL_CIPHER_VULN_IDS.any? { |id| @xml.attributes['id'].value.include?(id) }
         return result
       # And we need to clean up the tags with nested content in them
       elsif tags_with_nested_content.include?(method)
@@ -103,15 +103,9 @@ module Nexpose
 
     private
 
-    def cleanup_nested(source)
+    def add_bc_to_ssl_cipher_list(source)
       result = source.to_s
-      result.gsub!(/<references>/, '')
-      result.gsub!(/<\/references>/, '')
-      result.gsub!(/<reference source=\"(.*?)\">(.*?)<\/reference>/i) {"#{$1.strip}: #{$2.strip}\n"}
-      result.gsub!(/<tags>/, '')
-      result.gsub!(/<\/tags>/, '')
-      result.gsub!(/<tag>(.*?)<\/tag>/) {"#{$1}\n"}
-      result.gsub!(/        /, '')
+      result.gsub!(/\n(.*?)!(.*?)/){"\nbc. #{ $1 }!#{ $2 }\n"}
       result
     end
 
@@ -125,7 +119,7 @@ module Nexpose
       result.gsub!(/<UnorderedList>(.*?)<\/UnorderedList>/m){|m| "#{ $1 }"}
       result.gsub!(/<ListItem>(.*?)<\/ListItem>/m){|m| "#{ $1 }\n"}
       result.gsub!(/          /, '')
-      result.gsub!(/\t\t/, '')  
+      result.gsub!(/\t\t/, '')
       result.gsub!(/<URLLink LinkTitle=\"(.*?)\" LinkURL=\"(.*?)\"\/>/i) { "\"#{$1.strip}\":#{$2.strip} " }
       result.gsub!(/<URLLink LinkURL=\"(.*?)\" LinkTitle=\"(.*?)\"\/>/i) { "\"#{$2.strip}\":#{$1.strip} " }
       result.gsub!(/<URLLink(.*)LinkURL=\"(.*?)\"(.*?)>(.*?)<\/URLLink>/m) {|m| "\"#{$4.strip}\":#{$2.strip} " }
@@ -134,9 +128,15 @@ module Nexpose
       result
     end
 
-    def add_bc_to_ciphers(source)
+    def cleanup_nested(source)
       result = source.to_s
-      result.gsub!(/\n(.*?)!(.*?)/){"\nbc. #{ $1 }!#{ $2 }\n"}
+      result.gsub!(/<references>/, '')
+      result.gsub!(/<\/references>/, '')
+      result.gsub!(/<reference source=\"(.*?)\">(.*?)<\/reference>/i) {"#{$1.strip}: #{$2.strip}\n"}
+      result.gsub!(/<tags>/, '')
+      result.gsub!(/<\/tags>/, '')
+      result.gsub!(/<tag>(.*?)<\/tag>/) {"#{$1}\n"}
+      result.gsub!(/        /, '')
       result
     end
 

--- a/lib/nexpose/vulnerability.rb
+++ b/lib/nexpose/vulnerability.rb
@@ -115,12 +115,17 @@ module Nexpose
       result = source.to_s
       result.gsub!(/<ContainerBlockElement>(.*?)<\/ContainerBlockElement>/m){|m| "#{ $1 }"}
       result.gsub!(/<Paragraph preformat=\"true\">(.*?)<\/Paragraph>/m){|m| "\nbc. #{ $1 }\n\n"}
+
+      #This line automatically wraps ciphers in a code block
+      result.gsub!(/<Paragraph>(.*?)!(.*?)<\/Paragraph>/){"bc. #{ $1 }!#{ $2 }\n"}
+
       result.gsub!(/<Paragraph>(.*?)<\/Paragraph>/m){|m| "#{ $1 }\n"}
       result.gsub!(/<Paragraph>/, '')
       result.gsub!(/<\/Paragraph>/, '')
       result.gsub!(/<UnorderedList>(.*?)<\/UnorderedList>/m){|m| "#{ $1 }"}
       result.gsub!(/<ListItem>(.*?)<\/ListItem>/m){|m| "#{ $1 }\n"}
       result.gsub!(/          /, '')
+      result.gsub!(/\t\t/, '')  
       result.gsub!(/<URLLink LinkTitle=\"(.*?)\" LinkURL=\"(.*?)\"\/>/i) { "\"#{$1.strip}\":#{$2.strip} " }
       result.gsub!(/<URLLink LinkURL=\"(.*?)\" LinkTitle=\"(.*?)\"\/>/i) { "\"#{$2.strip}\":#{$1.strip} " }
       result.gsub!(/<URLLink(.*)LinkURL=\"(.*?)\"(.*?)>(.*?)<\/URLLink>/m) {|m| "\"#{$4.strip}\":#{$2.strip} " }

--- a/lib/nexpose/vulnerability.rb
+++ b/lib/nexpose/vulnerability.rb
@@ -8,7 +8,7 @@ module Nexpose
   # Instead of providing separate methods for each supported property we rely
   # on Ruby's #method_missing to do most of the work.
   class Vulnerability
-    SSL_CIPHER_VULN_IDS = %w[ssl].freeze
+    SSL_CIPHER_VULN_IDS = %w[ssl-3des-ciphers ssl-static-key-ciphers].freeze
 
     # Accepts an XML node from Nokogiri::XML.
     def initialize(xml_node)
@@ -79,7 +79,7 @@ module Nexpose
       # We need to clean up tags that have HTML content in them
       if tags_with_html_content.include?(method)
         result = cleanup_html(tag)
-        result = add_bc_to_ssl_cipher_list(result) if SSL_CIPHER_VULN_IDS.any? { |id| @xml.attributes['id'].value.include?(id) }
+        result = add_bc_to_ssl_cipher_list(result) if SSL_CIPHER_VULN_IDS.include?(@xml.attributes['id'].value)
         return result
       # And we need to clean up the tags with nested content in them
       elsif tags_with_nested_content.include?(method)

--- a/lib/nexpose/vulnerability.rb
+++ b/lib/nexpose/vulnerability.rb
@@ -77,7 +77,7 @@ module Nexpose
       # We need to clean up tags that have HTML content in them
       if tags_with_html_content.include?(method)
         result = cleanup_html(tag)
-        if @xml.attributes['id'].value.to_str.include? "ssl"
+        if @xml.attributes['id'].value.include? "ssl"
           result = add_bc_to_ciphers(result)
         end
         return result

--- a/lib/nexpose/vulnerability.rb
+++ b/lib/nexpose/vulnerability.rb
@@ -76,7 +76,11 @@ module Nexpose
 
       # We need to clean up tags that have HTML content in them
       if tags_with_html_content.include?(method)
-        return cleanup_html(tag)
+        result = cleanup_html(tag)
+        if @xml.attributes['id'].value.to_str.include? "ssl"
+          result = add_bc_to_ciphers(result)
+        end
+        return result
       # And we need to clean up the tags with nested content in them
       elsif tags_with_nested_content.include?(method)
         return cleanup_nested(nest)
@@ -115,10 +119,6 @@ module Nexpose
       result = source.to_s
       result.gsub!(/<ContainerBlockElement>(.*?)<\/ContainerBlockElement>/m){|m| "#{ $1 }"}
       result.gsub!(/<Paragraph preformat=\"true\">(.*?)<\/Paragraph>/m){|m| "\nbc. #{ $1 }\n\n"}
-
-      #This line automatically wraps ciphers in a code block
-      result.gsub!(/<Paragraph>(.*?)!(.*?)<\/Paragraph>/){"bc. #{ $1 }!#{ $2 }\n"}
-
       result.gsub!(/<Paragraph>(.*?)<\/Paragraph>/m){|m| "#{ $1 }\n"}
       result.gsub!(/<Paragraph>/, '')
       result.gsub!(/<\/Paragraph>/, '')
@@ -131,7 +131,12 @@ module Nexpose
       result.gsub!(/<URLLink(.*)LinkURL=\"(.*?)\"(.*?)>(.*?)<\/URLLink>/m) {|m| "\"#{$4.strip}\":#{$2.strip} " }
       result.gsub!(/&gt;/, '>')
       result.gsub!(/&lt;/, '<')
-      
+      result
+    end
+
+    def add_bc_to_ciphers(source)
+      result = source.to_s
+      result.gsub!(/\n(.*?)!(.*?)/){"\nbc. #{ $1 }!#{ $2 }\n"}
       result
     end
 

--- a/spec/fixtures/files/ssl.xml
+++ b/spec/fixtures/files/ssl.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<NexposeReport version="2.0">
+  <scans>
+    <scan endTime="20141110T175832478" id="4" name="USDA_Internal" startTime="20141110T094538362" status="finished"/>
+  </scans>
+  <nodes>
+    <node address="1.1.1.1" device-id="75" risk-score="0.0" scan-template="Edge Standard" site-importance="Normal" site-name="USDA_Internal" status="alive">
+      <fingerprints>
+        <os certainty="0.80" family="IOS" product="IOS" vendor="Cisco"/>
+      </fingerprints>
+      <tests/>
+      <endpoints>
+      </endpoints>
+    </node>
+  </nodes>
+  <VulnerabilityDefinitions>
+    <vulnerability id="ssl-3des-ciphers" title="TLS/SSL Server Supports 3DES Cipher Suite" severity="1" pciSeverity="1" cvssScore="0.0" cvssVector="(AV:N/AC:H/Au:N/C:N/I:N/A:N)" published="20090201T000000000" added="20150930T000000000" modified="20181127T000000000" riskScore="0.0">
+		<malware></malware><exploits></exploits><description>
+
+		<ContainerBlockElement>
+		    
+			<Paragraph>
+		      Transport Layer Security (TLS) versions 1.0 (RFC 2246) and 1.1 (RFC 4346) include cipher suites based on the
+		      3DES (Triple Data Encryption Standard) algorithm.
+		      Since 3DES only provides an effective security of 112 bits, it is considered close to end of life by some agencies. Consequently, the 3DES algorithm is not included in the specifications for TLS version 1.3.
+		      ECRYPT II (from 2012) recommends for generic application independent long-term protection at least 128 bits security. The same recommendation has also been reported by BSI Germany (from 2015) and ANSSI France (from 2014), 128 bit is the recommended symmetric size and should be mandatory after 2020. While NIST (from 2012) still considers 3DES being appropriate to use until the end of 2030.
+		    </Paragraph>
+		  </ContainerBlockElement></description>
+		<references>
+		<reference source="URL">http://www.nist.gov/manuscript-publication-search.cfm?pub_id=915295</reference>
+		<reference source="URL">http://www.ecrypt.eu.org/ecrypt2/documents/D.SPA.20.pdf</reference>
+		<reference source="URL">http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-52r1.pdf</reference>
+		<reference source="URL">https://wiki.mozilla.org/Security/Server_Side_TLS</reference>
+		<reference source="URL">https://www.owasp.org/index.php/Transport_Layer_Protection_Cheat_Sheet#Rule_-_Only_Support_Strong_Cryptographic_Ciphers</reference>
+		<reference source="URL">http://support.microsoft.com/kb/245030/</reference>
+		</references><tags>
+		<tag>Network</tag>
+		</tags>
+		<solution>
+
+		<ContainerBlockElement>
+			<Paragraph>
+				<Paragraph>Configure the server to disable support for 3DES suite.</Paragraph>
+				<Paragraph>For Microsoft IIS web servers, see Microsoft Knowledgebase article
+		         
+				<URLLink LinkURL="http://support.microsoft.com/kb/245030/" href="http://support.microsoft.com/kb/245030/" LinkTitle="http://support.microsoft.com/kb/245030/">245030</URLLink> for instructions on disabling 3DES cipher suite.
+		      </Paragraph>
+				<Paragraph>The following recommended configuration provides a higher level of security. This configuration is compatible with Firefox 27, Chrome 22, IE 11, Opera 14 and Safari 7. SSLv2, SSLv3, and TLSv1 protocols are not recommended in this configuration. Instead, use TLSv1.1 and TLSv1.2 protocols.</Paragraph>
+				<Paragraph>Refer to your server vendor documentation to apply the recommended cipher configuration:</Paragraph>
+				<Paragraph>ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!3DES:!MD5:!PSK</Paragraph></Paragraph></ContainerBlockElement></solution>
+		</vulnerability>
+  </VulnerabilityDefinitions>
+</NexposeReport>

--- a/spec/nexpose_upload_spec.rb
+++ b/spec/nexpose_upload_spec.rb
@@ -126,6 +126,15 @@ describe 'Nexpose upload plugin' do
       @importer.import(file: 'spec/fixtures/files/full.xml')
     end
 
+    it "wraps ciphers inside ssl issues in code blocks" do
+      expect(@content_service).to receive(:create_issue) do |args|
+        expect(args[:text]).to include("bc. ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256")
+        OpenStruct.new(args)
+      end.once
+
+      @importer.import(file: 'spec/fixtures/files/ssl.xml')
+    end
+
     # Regression test for github.com/dradis/dradis-nexpose/issues/1
     it "populates solutions regardless they are wrapped in paragraphs or lists" do
       expect(@content_service).to receive(:create_issue) do |args|


### PR DESCRIPTION
In the Solution and Description tags, there are sometimes ciphers that appear within regular paragraph text. The `!` in the ciphers will cause the Dradis exporter to think that we're trying to export a screenshot unless the ciphers are wrapped in `bc. `. This PR adds a gsub to catch ciphers that need to be wrapped in code block. 