### PR TITLE
Add risk_score as a Node property and as an available Node field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Dradis Framework 3.14 (XXX, 2019) ##
+
+*   Add risk-score attribute to nodes
+
 ## Dradis Framework 3.13 (June, 2019) ##
 
 *   No changes.

--- a/dradis-nexpose.gemspec
+++ b/dradis-nexpose.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'dradis-plugins', '~> 3.6'
   spec.add_dependency 'nokogiri', '~> 1.3'
 
-  spec.add_development_dependency 'bundler', '>= 1.6'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec-rails'
   spec.add_development_dependency 'combustion', '~> 0.5.2'

--- a/dradis-nexpose.gemspec
+++ b/dradis-nexpose.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'dradis-plugins', '~> 3.6'
   spec.add_dependency 'nokogiri', '~> 1.3'
 
-  spec.add_development_dependency 'bundler', '~> 1.6'
+  spec.add_development_dependency 'bundler', '>= 1.6'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec-rails'
   spec.add_development_dependency 'combustion', '~> 0.5.2'

--- a/lib/dradis/plugins/nexpose/formats/full.rb
+++ b/lib/dradis/plugins/nexpose/formats/full.rb
@@ -36,6 +36,7 @@ module Dradis::Plugins::Nexpose::Formats
           host_node.set_property(:ip, nexpose_node.address)
           host_node.set_property(:hostname, nexpose_node.site_name)
           host_node.set_property(:os, nexpose_node.software)
+          host_node.set_property(:risk_score, nexpose_node.risk_score)
           host_node.save
         end
 

--- a/lib/dradis/plugins/nexpose/gem_version.rb
+++ b/lib/dradis/plugins/nexpose/gem_version.rb
@@ -8,9 +8,9 @@ module Dradis
 
       module VERSION
         MAJOR = 3
-        MINOR = 13
+        MINOR = 14
         TINY = 0
-        PRE = nil
+        PRE = 'rc1'
 
         STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")
       end

--- a/lib/nexpose/node.rb
+++ b/lib/nexpose/node.rb
@@ -18,7 +18,7 @@ module Nexpose
     def supported_tags
       [
         # attributes
-        :address, :device_id, :hardware_address, :site_name, :status,
+        :address, :device_id, :hardware_address, :site_name, :status, :risk_score,
 
         # simple tags
 
@@ -73,7 +73,8 @@ module Nexpose
       translations_table = {
         :device_id => 'device-id',
         :hardware_address => 'hardware-address',
-        :site_name => 'site-name'
+        :site_name => 'site-name',
+        :risk_score => 'risk-score'
       }
 
       method_name = translations_table.fetch(method, method.to_s)

--- a/lib/nexpose/node.rb
+++ b/lib/nexpose/node.rb
@@ -18,7 +18,7 @@ module Nexpose
     def supported_tags
       [
         # attributes
-        :address, :device_id, :hardware_address, :site_name, :status, :risk_score,
+        :address, :device_id, :hardware_address, :risk_score, :site_name, :status,
 
         # simple tags
 
@@ -71,10 +71,10 @@ module Nexpose
       # First we try the attributes. In Ruby we use snake_case, but in XML
       # hyphenated-case is used for some attributes
       translations_table = {
-        :device_id => 'device-id',
-        :hardware_address => 'hardware-address',
-        :site_name => 'site-name',
-        :risk_score => 'risk-score'
+        device_id: 'device-id',
+        hardware_address: 'hardware-address',
+        risk_score: 'risk-score',
+        site_name: 'site-name'
       }
 
       method_name = translations_table.fetch(method, method.to_s)

--- a/lib/nexpose/vulnerability.rb
+++ b/lib/nexpose/vulnerability.rb
@@ -124,7 +124,9 @@ module Nexpose
       result.gsub!(/<URLLink LinkTitle=\"(.*?)\" LinkURL=\"(.*?)\"\/>/i) { "\"#{$1.strip}\":#{$2.strip} " }
       result.gsub!(/<URLLink LinkURL=\"(.*?)\" LinkTitle=\"(.*?)\"\/>/i) { "\"#{$2.strip}\":#{$1.strip} " }
       result.gsub!(/<URLLink(.*)LinkURL=\"(.*?)\"(.*?)>(.*?)<\/URLLink>/m) {|m| "\"#{$4.strip}\":#{$2.strip} " }
-
+      result.gsub!(/&gt;/, '>')
+      result.gsub!(/&lt;/, '<')
+      
       result
     end
 

--- a/spec/nexpose_upload_spec.rb
+++ b/spec/nexpose_upload_spec.rb
@@ -86,7 +86,10 @@ describe 'Nexpose upload plugin' do
         expect(args[:node].label).to eq("Nexpose Scan Summary")
       end.once
 
-      expect(@content_service).to receive(:create_node).with(hash_including label: "1.1.1.1", type: :host).once
+      expect(@content_service).to receive(:create_node).with(
+        hash_including label: "1.1.1.1", type: :host
+      ).twice
+
       expect(@content_service).to receive(:create_note) do |args|
         expect(args[:text]).to include("#[Title]#\n1.1.1.1")
         expect(args[:node].label).to eq("1.1.1.1")
@@ -97,10 +100,6 @@ describe 'Nexpose upload plugin' do
         expect(args[:node].label).to eq("1.1.1.1")
       end.once
 
-      expect(@content_service).to receive(:create_node) do |args|
-        expect(args[:label]).to eq("1.1.1.1")
-        OpenStruct.new(args)
-      end.once
       expect(@content_service).to receive(:create_note) do |args|
         expect(args[:text]).to include("#[Title]#\nService name: SNMP")
         expect(args[:node].label).to eq("1.1.1.1")

--- a/spec/nexpose_upload_spec.rb
+++ b/spec/nexpose_upload_spec.rb
@@ -88,14 +88,10 @@ describe 'Nexpose upload plugin' do
 
       expect(@content_service).to receive(:create_node).with(hash_including label: "1.1.1.1", type: :host).once
       expect(@content_service).to receive(:create_note) do |args|
-        expect(args[:text]).to include("#[Host]#\n1.1.1.1")
+        expect(args[:text]).to include("#[Title]#\n1.1.1.1")
         expect(args[:node].label).to eq("1.1.1.1")
       end.once
 
-      expect(@content_service).to receive(:create_node) do |args|
-        expect(args[:label]).to eq("Definitions")
-        OpenStruct.new(args)
-      end.once
       expect(@content_service).to receive(:create_note) do |args|
         expect(args[:text]).to include("#[Title]#\nService name: NTP")
         expect(args[:node].label).to eq("1.1.1.1")
@@ -134,12 +130,13 @@ describe 'Nexpose upload plugin' do
     # Regression test for github.com/dradis/dradis-nexpose/issues/1
     it "populates solutions regardless they are wrapped in paragraphs or lists" do
       expect(@content_service).to receive(:create_issue) do |args|
-        expect(args[:text]).to include("#[Solution]#\nApache HTTPD >= 2.0 and < 2.0.65")
+        expect(args[:text]).to include("#[Solution]#\n\nApache HTTPD >= 2.0 and < 2.0.65")
         OpenStruct.new(args)
       end.once
 
       expect(@content_service).to receive(:create_issue) do |args|
-        expect(args[:text]).to include("#[Solution]#\nYou can remove inode information from the ETag header")
+        expect(args[:text]).to include("#[Solution]#\n")
+        expect(args[:text]).to include("You can remove inode information from the ETag header")
         OpenStruct.new(args)
       end.once
 

--- a/spec/nexpose_upload_spec.rb
+++ b/spec/nexpose_upload_spec.rb
@@ -141,5 +141,14 @@ describe 'Nexpose upload plugin' do
 
       @importer.import(file: 'spec/fixtures/files/full.xml')
     end
+
+    it "transforms html entities (&lt; and &gt;)" do
+      expect(@content_service).to receive(:create_issue) do |args|
+        expect(args[:text]).to include("#[Solution]#\n\nApache HTTPD >= 2.0 and < 2.0.65")
+        OpenStruct.new(args)
+      end
+
+      @importer.import(file: 'spec/fixtures/files/full.xml')
+    end
   end
 end

--- a/templates/full_node.fields
+++ b/templates/full_node.fields
@@ -4,7 +4,7 @@ node.fingerprints
 node.hardware_address
 node.names
 node.tests
+node.risk_score
 node.site_name
 node.status
 node.software
-node.risk_score

--- a/templates/full_node.fields
+++ b/templates/full_node.fields
@@ -7,3 +7,4 @@ node.tests
 node.site_name
 node.status
 node.software
+node.risk_score

--- a/templates/full_node.sample
+++ b/templates/full_node.sample
@@ -3,7 +3,8 @@
   site-name="snorby"
   status="alive"
   device-id="211"
-  hardware-address="00:de:ad:be:ef:00">
+  hardware-address="00:de:ad:be:ef:00"
+  risk-score="123">
 
   <names>
       <name>iPad.local</name>


### PR DESCRIPTION
Nexpose includes a risk score for each Node. This PR improves our plugin to pull in this data as a node property and as a new field in the plugin manager for the Node template. 