### PR TITLE
Expand coverage for cipher wrapping to more issue IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Dradis Framework 3.16 (XXXX, 2020) ##
+
+*   Expand coverage for cipher wrapping
+
 ## Dradis Framework 3.15 (November, 2019) ##
 
 *   Wrap ciphers in code blocks

--- a/lib/nexpose/vulnerability.rb
+++ b/lib/nexpose/vulnerability.rb
@@ -8,7 +8,7 @@ module Nexpose
   # Instead of providing separate methods for each supported property we rely
   # on Ruby's #method_missing to do most of the work.
   class Vulnerability
-    SSL_CIPHER_VULN_IDS = %w[ssl-3des-ciphers ssl-static-key-ciphers].freeze
+    SSL_CIPHER_VULN_IDS = %w[ssl-des-ciphers ssl-3des-ciphers ssl-export-ciphers ssl-static-key-ciphers rc4-cve-2013-2566 ssl-cve-2016-2183-sweet32 tls-dhe-export-ciphers-cve-2015-4000].freeze
 
     # Accepts an XML node from Nokogiri::XML.
     def initialize(xml_node)
@@ -30,7 +30,7 @@ module Nexpose
         :references, :tags,
 
         # evidence tag
-        :details
+        :details, :name
       ]
     end
 
@@ -96,6 +96,8 @@ module Nexpose
           text.split("\n").
           collect(&:strip).
           reject{|line| line.empty?}.join("\n")
+      elsif method_name == 'name'
+        return @xml.xpath('./names/name').collect(&:text).join("\n")
       end
 
       nil

--- a/lib/nexpose/vulnerability.rb
+++ b/lib/nexpose/vulnerability.rb
@@ -30,7 +30,7 @@ module Nexpose
         :references, :tags,
 
         # evidence tag
-        :details, :name
+        :details
       ]
     end
 
@@ -96,8 +96,6 @@ module Nexpose
           text.split("\n").
           collect(&:strip).
           reject{|line| line.empty?}.join("\n")
-      elsif method_name == 'name'
-        return @xml.xpath('./names/name').collect(&:text).join("\n")
       end
 
       nil


### PR DESCRIPTION
### Summary
We have logic built in to the plugin that wraps ciphers in code blocks if the Issue ID matches a list of Issues known to have ciphers in them. Based on a sample file a team sent us, this PR expands the coverage to more IDs that are known to contain ciphers. 

### Copyright assignment
> I assign all rights, including copyright, to any future Dradis work by myself to Security Roots.