### PR TITLE
Add "ssl-null-ciphers" to list of IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
-## Dradis Framework 3.17 (XXXX, 2020) ##
+## Dradis Framework 3.19 (XXXX, 2020) ##
+
+*   Expand coverage for cipher wrapping
+
+## Dradis Framework 3.18 (July, 2020) ##
+
+*   No changes.
+
+## Dradis Framework 3.17 (May, 2020) ##
 
 *   Expand coverage for cipher wrapping
 

--- a/lib/nexpose/vulnerability.rb
+++ b/lib/nexpose/vulnerability.rb
@@ -8,7 +8,7 @@ module Nexpose
   # Instead of providing separate methods for each supported property we rely
   # on Ruby's #method_missing to do most of the work.
   class Vulnerability
-    SSL_CIPHER_VULN_IDS = %w[ssl-des-ciphers ssl-3des-ciphers ssl-export-ciphers ssl-static-key-ciphers rc4-cve-2013-2566 ssl-cve-2016-2183-sweet32 tls-dhe-export-ciphers-cve-2015-4000].freeze
+    SSL_CIPHER_VULN_IDS = %w[ssl-des-ciphers ssl-3des-ciphers ssl-export-ciphers ssl-null-ciphers ssl-static-key-ciphers rc4-cve-2013-2566 ssl-cve-2016-2183-sweet32 tls-dhe-export-ciphers-cve-2015-4000].freeze
 
     # Accepts an XML node from Nokogiri::XML.
     def initialize(xml_node)


### PR DESCRIPTION
### Summary
The list of IDs that get wrapped in code blocks was missing `ssl-null-ciphers`

### Copyright assignment
> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.
