### PR TITLE
Update the way that HTML tags are dealt with

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Dradis Framework X.X (XXXX, 2021) ##
+
+*   Update HTML tag cleanup
+
 ## Dradis Framework 3.22 (April, 2021) ##
 
 *   No changes.

--- a/lib/nexpose/vulnerability.rb
+++ b/lib/nexpose/vulnerability.rb
@@ -112,17 +112,18 @@ module Nexpose
     def cleanup_html(source)
       result = source.to_s
       result.gsub!(/<ContainerBlockElement>(.*?)<\/ContainerBlockElement>/m){|m| "#{ $1 }"}
-      result.gsub!(/<Paragraph preformat=\"true\">(.*?)<\/Paragraph>/m){|m| "\nbc. #{ $1 }\n\n"}
+      result.gsub!(/<Paragraph preformat=\"true\">(.*?)<\/Paragraph>/mi){|m| "\nbc. #{ $1 }\n\n"}
       result.gsub!(/<Paragraph>(.*?)<\/Paragraph>/m){|m| "#{ $1 }\n"}
-      result.gsub!(/<Paragraph>/, '')
-      result.gsub!(/<\/Paragraph>/, '')
+      result.gsub!(/<Paragraph>|<\/Paragraph>/, '')
       result.gsub!(/<UnorderedList>(.*?)<\/UnorderedList>/m){|m| "#{ $1 }"}
-      result.gsub!(/<ListItem>(.*?)<\/ListItem>/m){|m| "#{ $1 }\n"}
+      result.gsub!(/<OrderedList(.*?)>(.*?)<\/OrderedList>/m){|m| "#{ $2 }"}
+      result.gsub!(/<ListItem>|<\/ListItem>/, '')
       result.gsub!(/          /, '')
+      result.gsub!(/   /, '')
       result.gsub!(/\t\t/, '')
-      result.gsub!(/<URLLink LinkTitle=\"(.*?)\" LinkURL=\"(.*?)\"\/>/i) { "\"#{$1.strip}\":#{$2.strip} " }
-      result.gsub!(/<URLLink LinkURL=\"(.*?)\" LinkTitle=\"(.*?)\"\/>/i) { "\"#{$2.strip}\":#{$1.strip} " }
-      result.gsub!(/<URLLink(.*)LinkURL=\"(.*?)\"(.*?)>(.*?)<\/URLLink>/m) {|m| "\"#{$4.strip}\":#{$2.strip} " }
+      result.gsub!(/<URLLink(.*)LinkURL=\"(.*?)\"(.*?)>(.*?)<\/URLLink>/i) { "\"#{$4.strip}\":#{$2.strip} " }
+      result.gsub!(/<URLLink LinkTitle=\"(.*?)\"(.*?)LinkURL=\"(.*?)\"\/>/i) { "\"#{$1.strip}\":#{$3.strip} " }
+      result.gsub!(/<URLLink LinkURL=\"(.*?)\"(.*?)LinkTitle=\"(.*?)\"\/>/i) { "\"#{$3.strip}\":#{$1.strip} " }
       result.gsub!(/&gt;/, '>')
       result.gsub!(/&lt;/, '<')
       result


### PR DESCRIPTION
### Summary
Currently, tags, especially links, are parsed in a way that causes whole paragraphs to go missing on import. 
And, the new <OrderedList> tag needs to be removed. 
And finally, a new line is introduced so that there is only one space between `bc.` and the content. 
This PR resolves things. 


> I assign all rights, including copyright, to any future Dradis work by myself to Security Roots.
