### PR TITLE
Expand cipher coverage to include ssl-anon-ciphers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Dradis Framework X.X (XXXX, 2021) ##
 
+*   Expand coverage for cipher wrapping
+
+## Dradis Framework 4.0 (August, 2021) ##
+
 *   Update HTML tag cleanup
 
 ## Dradis Framework 3.22 (April, 2021) ##

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Dradis Framework X.X (XXXX, 2021) ##
 
-*   Expand coverage for cipher wrapping
+*   Expand coverage for cipher wrapping to ssl-anon-ciphers and ssl-only-weak-ciphers
 
 ## Dradis Framework 4.0 (August, 2021) ##
 

--- a/lib/nexpose/vulnerability.rb
+++ b/lib/nexpose/vulnerability.rb
@@ -8,7 +8,7 @@ module Nexpose
   # Instead of providing separate methods for each supported property we rely
   # on Ruby's #method_missing to do most of the work.
   class Vulnerability
-    SSL_CIPHER_VULN_IDS = %w[ssl-des-ciphers ssl-3des-ciphers ssl-export-ciphers ssl-null-ciphers ssl-static-key-ciphers rc4-cve-2013-2566 ssl-cve-2016-2183-sweet32 tls-dhe-export-ciphers-cve-2015-4000].freeze
+    SSL_CIPHER_VULN_IDS = %w[ssl-anon-ciphers ssl-des-ciphers ssl-3des-ciphers ssl-export-ciphers ssl-null-ciphers ssl-static-key-ciphers rc4-cve-2013-2566 ssl-cve-2016-2183-sweet32 tls-dhe-export-ciphers-cve-2015-4000].freeze
 
     # Accepts an XML node from Nokogiri::XML.
     def initialize(xml_node)

--- a/lib/nexpose/vulnerability.rb
+++ b/lib/nexpose/vulnerability.rb
@@ -8,7 +8,7 @@ module Nexpose
   # Instead of providing separate methods for each supported property we rely
   # on Ruby's #method_missing to do most of the work.
   class Vulnerability
-    SSL_CIPHER_VULN_IDS = %w[ssl-anon-ciphers ssl-des-ciphers ssl-3des-ciphers ssl-export-ciphers ssl-null-ciphers ssl-static-key-ciphers rc4-cve-2013-2566 ssl-cve-2016-2183-sweet32 tls-dhe-export-ciphers-cve-2015-4000].freeze
+    SSL_CIPHER_VULN_IDS = %w[ssl-anon-ciphers ssl-des-ciphers ssl-3des-ciphers ssl-export-ciphers ssl-null-ciphers ssl-only-weak-ciphers ssl-static-key-ciphers rc4-cve-2013-2566 ssl-cve-2016-2183-sweet32 tls-dhe-export-ciphers-cve-2015-4000].freeze
 
     # Accepts an XML node from Nokogiri::XML.
     def initialize(xml_node)


### PR DESCRIPTION
### Summary

A user reported that `ssl-anon-ciphers` contains unwrapped ciphers. This PR makes sure that future instances of that issue will have the cipher wrapped in a `bc. `. 

> I assign all rights, including copyright, to any future Dradis work by myself to Security Roots.
