### PR TITLE
Expand cleanup_html to capture differently-formatted tags in the Solution field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Dradis Framework 4.1.0 (XXXX, 2021) ##
+
+*   Update HTML tag cleanup
+
 ## Dradis Framework 4.0.0 (July, 2021) ##
 
 *   Update HTML tag cleanup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Dradis Framework 4.1.0 (XXXX, 2021) ##
 
-*   Update HTML tag cleanup
+*   Update HTML tag cleanup to better cover `UnorderedList` and `URLLink` tags in the solution field
 
 ## Dradis Framework 4.0.0 (July, 2021) ##
 

--- a/lib/dradis/plugins/nexpose/gem_version.rb
+++ b/lib/dradis/plugins/nexpose/gem_version.rb
@@ -9,7 +9,7 @@ module Dradis
       module VERSION
         MAJOR = 4
         MINOR = 0
-        TINY = 0
+        TINY = 1
         PRE = nil
 
         STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")

--- a/lib/nexpose/vulnerability.rb
+++ b/lib/nexpose/vulnerability.rb
@@ -115,8 +115,7 @@ module Nexpose
       result.gsub!(/<Paragraph preformat=\"true\">(.*?)<\/Paragraph>/mi){|m| "\nbc. #{ $1 }\n\n"}
       result.gsub!(/<Paragraph>(.*?)<\/Paragraph>/m){|m| "#{ $1 }\n"}
       result.gsub!(/<Paragraph>|<\/Paragraph>/, '')
-      result.gsub!(/<UnorderedList>(.*?)<\/UnorderedList>/m){|m| "#{ $1 }"}
-      result.gsub!(/<UnorderedList (.*?)>|<\/UnorderedList>/, '')
+      result.gsub!(/<UnorderedList (.*?)>(.*?)<\/UnorderedList>/m){|m| "#{ $2 }"}
       result.gsub!(/<OrderedList(.*?)>(.*?)<\/OrderedList>/m){|m| "#{ $2 }"}
       result.gsub!(/<ListItem>|<\/ListItem>/, '')
       result.gsub!(/          /, '')

--- a/lib/nexpose/vulnerability.rb
+++ b/lib/nexpose/vulnerability.rb
@@ -122,7 +122,7 @@ module Nexpose
       result.gsub!(/          /, '')
       result.gsub!(/   /, '')
       result.gsub!(/\t\t/, '')
-      result.gsub!(/<URLLink(.*)LinkURL=\"(.*?)\"(.*?)>(.*?)<\/URLLink>/i) { "\"#{$4.strip}\":#{$2.strip} " }
+      result.gsub!(/<URLLink(.*)LinkURL=\"(.*?)\"(.*?)>(.*?)<\/URLLink>/im) { "\"#{$4.strip}\":#{$2.strip} " }
       result.gsub!(/<URLLink LinkTitle=\"(.*?)\"(.*?)LinkURL=\"(.*?)\"\/>/i) { "\"#{$1.strip}\":#{$3.strip} " }
       result.gsub!(/<URLLink LinkURL=\"(.*?)\"(.*?)LinkTitle=\"(.*?)\"\/>/i) { "\"#{$3.strip}\":#{$1.strip} " }
       result.gsub!(/&gt;/, '>')

--- a/lib/nexpose/vulnerability.rb
+++ b/lib/nexpose/vulnerability.rb
@@ -116,6 +116,7 @@ module Nexpose
       result.gsub!(/<Paragraph>(.*?)<\/Paragraph>/m){|m| "#{ $1 }\n"}
       result.gsub!(/<Paragraph>|<\/Paragraph>/, '')
       result.gsub!(/<UnorderedList>(.*?)<\/UnorderedList>/m){|m| "#{ $1 }"}
+      result.gsub!(/<UnorderedList (.*?)>|<\/UnorderedList>/, '')
       result.gsub!(/<OrderedList(.*?)>(.*?)<\/OrderedList>/m){|m| "#{ $2 }"}
       result.gsub!(/<ListItem>|<\/ListItem>/, '')
       result.gsub!(/          /, '')


### PR DESCRIPTION
### Summary
Currently, `cleanup_html` allows some instances of `UnorderedList` and `URLLink` to be imported without cleanup. This PR resolves that. 

> I assign all rights, including copyright, to any future Dradis work by myself to Security Roots.