### PR TITLE
Fix tag parsing for UnorderedList and double Paragraph preformat tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Dradis Framework 4.1.0 (XXXX, 2021) ##
 
 *   Update HTML tag cleanup to better cover `UnorderedList` and `URLLink` tags in the solution field
+*   Update HTML tag cleanup to cover `UnorderedList` tags without spaces and double `Paragraph preformat` tags
 
 ## Dradis Framework 4.0.0 (July, 2021) ##
 

--- a/lib/nexpose/vulnerability.rb
+++ b/lib/nexpose/vulnerability.rb
@@ -112,10 +112,11 @@ module Nexpose
     def cleanup_html(source)
       result = source.to_s
       result.gsub!(/<ContainerBlockElement>(.*?)<\/ContainerBlockElement>/m){|m| "#{ $1 }"}
+      result.gsub!(/<Paragraph preformat=\"true\">(\s*)<Paragraph preformat=\"true\">(.*?)<\/Paragraph>(\s*)<\/Paragraph>/mi){|m| "\nbc. #{ $2 }\n\n"}
       result.gsub!(/<Paragraph preformat=\"true\">(.*?)<\/Paragraph>/mi){|m| "\nbc. #{ $1 }\n\n"}
       result.gsub!(/<Paragraph>(.*?)<\/Paragraph>/m){|m| "#{ $1 }\n"}
       result.gsub!(/<Paragraph>|<\/Paragraph>/, '')
-      result.gsub!(/<UnorderedList (.*?)>(.*?)<\/UnorderedList>/m){|m| "#{ $2 }"}
+      result.gsub!(/<UnorderedList(.*?)>(.*?)<\/UnorderedList>/m){|m| "#{ $2 }"}
       result.gsub!(/<OrderedList(.*?)>(.*?)<\/OrderedList>/m){|m| "#{ $2 }"}
       result.gsub!(/<ListItem>|<\/ListItem>/, '')
       result.gsub!(/          /, '')


### PR DESCRIPTION
### Summary
This PR resolves HTML formatting issues with <UnorderedList> tags (no spaces) and also doubled tags like: 

```
<Paragraph preformat="true">
	<Paragraph preformat="true">
            example
</Paragraph></Paragraph>
```

> I assign all rights, including copyright, to any future Dradis work by myself to Security Roots.
