### PR TITLE
Use names as hostname rather than site-name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+v4.X.X (XXXX 2022)
+  - Pull the Hostname Node property from the `name` rather than `site-name` tag
+
 v4.1.0 (November 2021)
   - Update HTML tag cleanup to better cover `UnorderedList` and `URLLink` tags in the solution field
 

--- a/lib/dradis/plugins/nexpose/formats/full.rb
+++ b/lib/dradis/plugins/nexpose/formats/full.rb
@@ -34,7 +34,7 @@ module Dradis::Plugins::Nexpose::Formats
         if host_node.respond_to?(:properties)
           logger.info{ "\tAdding host properties to #{nexpose_node.address}"}
           host_node.set_property(:ip, nexpose_node.address)
-          host_node.set_property(:hostname, nexpose_node.site_name)
+          host_node.set_property(:hostname, nexpose_node.names)
           host_node.set_property(:os, nexpose_node.software)
           host_node.set_property(:risk_score, nexpose_node.risk_score)
           host_node.save

--- a/spec/fixtures/files/full.xml
+++ b/spec/fixtures/files/full.xml
@@ -5,6 +5,9 @@
   </scans>
   <nodes>
     <node address="1.1.1.1" device-id="75" risk-score="0.0" scan-template="Edge Standard" site-importance="Normal" site-name="USDA_Internal" status="alive">
+      <names>
+        <name>localhost:5000</name>
+      </names>
       <fingerprints>
         <os certainty="0.80" family="IOS" product="IOS" vendor="Cisco"/>
       </fingerprints>

--- a/spec/nexpose_upload_spec.rb
+++ b/spec/nexpose_upload_spec.rb
@@ -79,7 +79,6 @@ describe 'Nexpose upload plugin' do
 
   describe "Importer: Full" do
     it "creates nodes, issues, notes and an evidences as needed" do
-
       expect(@content_service).to receive(:create_node).with(hash_including label: "Nexpose Scan Summary").once
       expect(@content_service).to receive(:create_note) do |args|
         expect(args[:text]).to include("#[Title]#\nUSDA_Internal (4)")
@@ -122,6 +121,14 @@ describe 'Nexpose upload plugin' do
         expect(args[:issue].id).to eq("ntp-clock-variables-disclosure")
         expect(args[:node].label).to eq("1.1.1.1")
       end.once
+
+      allow_any_instance_of(OpenStruct).to receive(:respond_to?).with(:properties).and_return(true)
+      allow_any_instance_of(OpenStruct).to receive(:set_service).and_return(true)
+
+      expect_any_instance_of(OpenStruct).to receive(:set_property).with(:hostname, ['localhost:5000'])
+      expect_any_instance_of(OpenStruct).to receive(:set_property).with(:ip, '1.1.1.1')
+      expect_any_instance_of(OpenStruct).to receive(:set_property).with(:os, [])
+      expect_any_instance_of(OpenStruct).to receive(:set_property).with(:risk_score, '0.0')
 
       @importer.import(file: 'spec/fixtures/files/full.xml')
     end


### PR DESCRIPTION
### Summary
Currently, the hostname Node property is pulling in the contents of the Node's "site-name". However, "site-name" is actually the scan name, and the contents of the `<name>` tag are actually the hostname.

> I assign all rights, including copyright, to any future Dradis work by myself to Security Roots.