### PR TITLE
Cover ** and UnorderedList tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 v4.3.0 (April 2022)
+  - Parse `**` correctly and clean up `UnorderedList` tags in the description field
   - Update HTML tag cleanup to cover `UnorderedList` tags without spaces and double `Paragraph preformat` tags
 
 v4.2.0 (February 2022)
   - Pull the Hostname Node property from the `name` rather than `site-name` tag
-  - Parse `**` correctly and clean up `UnorderedList` tags in the description field
 
 v4.1.0 (November 2021)
   - Update HTML tag cleanup to better cover `UnorderedList` and `URLLink` tags in the solution field

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 v4.X.X (XXXX 2022)
   - Pull the Hostname Node property from the `name` rather than `site-name` tag
+  - Parse `**` correctly and clean up `UnorderedList` tags in the description field
 
 v4.1.0 (November 2021)
   - Update HTML tag cleanup to better cover `UnorderedList` and `URLLink` tags in the solution field

--- a/lib/dradis/plugins/nexpose/gem_version.rb
+++ b/lib/dradis/plugins/nexpose/gem_version.rb
@@ -9,7 +9,7 @@ module Dradis
       module VERSION
         MAJOR = 4
         MINOR = 1
-        TINY = 0
+        TINY = 1
         PRE = nil
 
         STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")

--- a/lib/nexpose/vulnerability.rb
+++ b/lib/nexpose/vulnerability.rb
@@ -116,10 +116,9 @@ module Nexpose
       result.gsub!(/<Paragraph preformat=\"true\">(.*?)<\/Paragraph>/mi){|m| "\nbc. #{ $1 }\n\n"}
       result.gsub!(/<Paragraph>(.*?)<\/Paragraph>/m){|m| "#{ $1 }\n"}
       result.gsub!(/<Paragraph>|<\/Paragraph>/, '')
-      result.gsub!(/<UnorderedList(.*?)>(.*?)<\/UnorderedList>/m){|m| "#{ $2 }"}
+      result.gsub!(/<UnorderedList>|<\/UnorderedList>/, '')
       result.gsub!(/<OrderedList(.*?)>(.*?)<\/OrderedList>/m){|m| "#{ $2 }"}
       result.gsub!(/<ListItem>|<\/ListItem>/, '')
-      result.gsub!(/<UnorderedList>|<\/UnorderedList>/, '')
       result.gsub!(/^\s*\*\*/, 'p. **')
       result.gsub!(/          /, '')
       result.gsub!(/   /, '')

--- a/lib/nexpose/vulnerability.rb
+++ b/lib/nexpose/vulnerability.rb
@@ -119,7 +119,7 @@ module Nexpose
       result.gsub!(/<OrderedList(.*?)>(.*?)<\/OrderedList>/m){|m| "#{ $2 }"}
       result.gsub!(/<ListItem>|<\/ListItem>/, '')
       result.gsub!(/<UnorderedList>|<\/UnorderedList>/, '')
-      result.gsub!(/^\s\*\*/, 'p. **')
+      result.gsub!(/^\s*\*\*/, 'p. **')
       result.gsub!(/          /, '')
       result.gsub!(/   /, '')
       result.gsub!(/\t\t/, '')

--- a/lib/nexpose/vulnerability.rb
+++ b/lib/nexpose/vulnerability.rb
@@ -115,9 +115,11 @@ module Nexpose
       result.gsub!(/<Paragraph preformat=\"true\">(.*?)<\/Paragraph>/mi){|m| "\nbc. #{ $1 }\n\n"}
       result.gsub!(/<Paragraph>(.*?)<\/Paragraph>/m){|m| "#{ $1 }\n"}
       result.gsub!(/<Paragraph>|<\/Paragraph>/, '')
-      result.gsub!(/<UnorderedList (.*?)>(.*?)<\/UnorderedList>/m){|m| "#{ $2 }"}
+      result.gsub!(/<UnorderedList(.*?)>(.*?)<\/UnorderedList>/m){|m| "#{ $2 }"}
       result.gsub!(/<OrderedList(.*?)>(.*?)<\/OrderedList>/m){|m| "#{ $2 }"}
       result.gsub!(/<ListItem>|<\/ListItem>/, '')
+      result.gsub!(/<UnorderedList>|<\/UnorderedList>/, '')
+      result.gsub!(/\*\* | \*\*/, '*')
       result.gsub!(/          /, '')
       result.gsub!(/   /, '')
       result.gsub!(/\t\t/, '')

--- a/lib/nexpose/vulnerability.rb
+++ b/lib/nexpose/vulnerability.rb
@@ -119,7 +119,7 @@ module Nexpose
       result.gsub!(/<OrderedList(.*?)>(.*?)<\/OrderedList>/m){|m| "#{ $2 }"}
       result.gsub!(/<ListItem>|<\/ListItem>/, '')
       result.gsub!(/<UnorderedList>|<\/UnorderedList>/, '')
-      result.gsub!(/\*\* | \*\*/, '*')
+      result.gsub!(/^\s\*\*/, 'p. **')
       result.gsub!(/          /, '')
       result.gsub!(/   /, '')
       result.gsub!(/\t\t/, '')

--- a/spec/fixtures/files/double_asterisks.xml
+++ b/spec/fixtures/files/double_asterisks.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<NexposeReport version="2.0">
+  <scans>
+    <scan endTime="20141110T175832478" id="4" name="USDA_Internal" startTime="20141110T094538362" status="finished"/>
+  </scans>
+  <nodes>
+    <node address="1.1.1.1" device-id="75" risk-score="0.0" scan-template="Edge Standard" site-importance="Normal" site-name="USDA_Internal" status="alive">
+      <names>
+        <name>localhost:5000</name>
+      </names>
+      <fingerprints>
+        <os certainty="0.80" family="IOS" product="IOS" vendor="Cisco"/>
+      </fingerprints>
+      <tests/>
+      <endpoints>
+        <endpoint port="123" protocol="udp" status="open">
+          <services>
+            <service name="NTP">
+              <fingerprints>
+                <fingerprint certainty="0.90" family="NTP" product="NTP" vendor="Cisco"/>
+              </fingerprints>
+              <configuration>
+                <config name="ntp.variables">system=&quot;cisco&quot;, leap=0, stratum=5, rootdelay=88.21,
+
+rootdispersion=108.54, peer=24960, refid=135.89.100.96,
+
+reftime=0xD80BB6B5.715ACDD8, poll=10, clock=0xD80BB78F.8931F3F6,
+
+phase=8.259, freq=-141.24, error=11.32</config>
+              </configuration>
+              <tests>
+                <test id="ntp-clock-variables-disclosure" pci-compliance-status="pass" scan-id="4" status="vulnerable-exploited" vulnerable-since="20141110T161846666">
+                  <Paragraph>
+                    <Paragraph>The following NTP variables were found from a readvar request: system=&quot;cisco&quot;, leap=0, stratum=5, rootdelay=88.21,
+rootdispersion=108.54, peer=24960, refid=135.89.100.96,
+reftime=0xD80BB6B5.715ACDD8, poll=10, clock=0xD80BB78F.8931F3F6,
+phase=8.259, freq=-141.24, error=11.32</Paragraph>
+                  </Paragraph>
+                </test>
+              </tests>
+            </service>
+          </services>
+        </endpoint>
+        <endpoint port="161" protocol="udp" status="open">
+          <services>
+            <service name="SNMP">
+              <tests/>
+            </service>
+          </services>
+        </endpoint>
+      </endpoints>
+    </node>
+  </nodes>
+  <VulnerabilityDefinitions>
+    <vulnerability added="20120412T000000000" cvssScore="4.3" cvssVector="(AV:N/AC:M/Au:N/C:P/I:N/A:N)" id="ntp-clock-variables-disclosure" modified="20130828T000000000" pciSeverity="3" published="20031231T000000000" riskScore="549.07043" severity="4" title="Apache HTTPD: ETag Inode Information Leakage (CVE-2003-1418)">
+      <malware/>
+      <exploits/>
+      <description>
+        <ContainerBlockElement>
+          <Paragraph>** DISPUTED ** Apache HTTP server in certain configurations allows remote attackers to obtain sensitive information via (1) the ETag header, which reveals the inode number, or (2) multipart MIME boundary, which reveals child proccess IDs (PID).</Paragraph>
+        </ContainerBlockElement>
+      </description>
+      <references>
+        <reference source="BID">6939</reference>
+        <reference source="BID">6943</reference>
+        <reference source="CVE">CVE-2003-1418</reference>
+        <reference source="XF">11438</reference>
+      </references>
+      <tags>
+        <tag>Apache</tag>
+        <tag>Apache HTTP Server</tag>
+        <tag>Web</tag>
+      </tags>
+      <solution>
+        <ContainerBlockElement>
+          <UnorderedList>
+            <ListItem>
+              <Paragraph>
+                <Paragraph>You can remove inode information from the ETag header by adding the
+    following directive to your Apache config:</Paragraph>
+                <Paragraph preformat="true">FileETag MTime Size</Paragraph>
+              </Paragraph>
+            </ListItem>
+            <ListItem>
+              <Paragraph>OpenBSD</Paragraph>
+              <Paragraph>Download and apply the patch from:
+
+
+
+
+
+
+                <URLLink LinkTitle="http://www.openbsd.org/errata32.html#httpd" LinkURL="http://www.openbsd.org/errata32.html#httpd"/></Paragraph>
+              <Paragraph>
+                <Paragraph>The OpenBSD team has released a
+
+
+
+
+
+
+                  <URLLink LinkTitle="http://www.openbsd.org/errata32.html#httpd" LinkURL="http://www.openbsd.org/errata32.html#httpd" href="http://www.openbsd.org/errata32.html#httpd">patch</URLLink>
+                  for the Apache inode and pid leak problem.  This patch can be applied
+    cleanly to 3.2 stable and rebuilt.  Restart httpd for the changes to
+    take effect.  OpenBSD 3.3 will ship with the patched httpd by default.
+    The patch can be applied to earlier 3.x versions of OpenBSD, but it
+    may require editing of the source code.</Paragraph>
+              </Paragraph>
+            </ListItem>
+          </UnorderedList>
+        </ContainerBlockElement>
+      </solution>
+    </vulnerability>
+  </VulnerabilityDefinitions>
+</NexposeReport>

--- a/spec/nexpose_upload_spec.rb
+++ b/spec/nexpose_upload_spec.rb
@@ -166,5 +166,14 @@ describe 'Nexpose upload plugin' do
 
       @importer.import(file: 'spec/fixtures/files/full.xml')
     end
+
+    it 'appends textile paragraph (p. ) to text starting with double asterisks' do
+      expect(@content_service).to receive(:create_issue) do |args|
+        expect(args[:text]).to include("p. ** DISPUTED **")
+        OpenStruct.new(args)
+      end
+
+      @importer.import(file: 'spec/fixtures/files/double_asterisks.xml')
+    end
   end
 end


### PR DESCRIPTION
### Summary
Parse `**` correctly and clean up `UnorderedList` tags in the description field.

Instances of `**` can crash the entire Word export without a helpful error message to indicate the source of the problem. So, we need to remove them. 

This PR also includes a couple of updates to catch instances of `<UnorderedList>` tags that weren't caught by the previous logic. 

> I assign all rights, including copyright, to any future Dradis work by myself to Security Roots.
