### PR TITLE
Wrap ciphers in ssl-weak-message-authentication-code-algorithms finding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 v4.X.X (XXXX 2023)
   - Parse inline code, not just code blocks
+  - Wrap ciphers in the `ssl-weak-message-authentication-code-algorithms` finding
 
 v4.8.0 (April 2023)
   - No changes

--- a/lib/dradis/plugins/nexpose/gem_version.rb
+++ b/lib/dradis/plugins/nexpose/gem_version.rb
@@ -9,7 +9,7 @@ module Dradis
       module VERSION
         MAJOR = 4
         MINOR = 8
-        TINY = 1
+        TINY = 2
         PRE = nil
 
         STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")

--- a/lib/dradis/plugins/nexpose/gem_version.rb
+++ b/lib/dradis/plugins/nexpose/gem_version.rb
@@ -8,8 +8,8 @@ module Dradis
 
       module VERSION
         MAJOR = 4
-        MINOR = 8
-        TINY = 2
+        MINOR = 9
+        TINY = 0
         PRE = nil
 
         STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")

--- a/lib/nexpose/vulnerability.rb
+++ b/lib/nexpose/vulnerability.rb
@@ -8,7 +8,7 @@ module Nexpose
   # Instead of providing separate methods for each supported property we rely
   # on Ruby's #method_missing to do most of the work.
   class Vulnerability
-    SSL_CIPHER_VULN_IDS = %w[ssl-anon-ciphers ssl-des-ciphers ssl-3des-ciphers ssl-export-ciphers ssl-null-ciphers ssl-only-weak-ciphers ssl-static-key-ciphers rc4-cve-2013-2566 ssl-cve-2016-2183-sweet32 tls-dhe-export-ciphers-cve-2015-4000].freeze
+    SSL_CIPHER_VULN_IDS = %w[ssl-anon-ciphers ssl-des-ciphers ssl-3des-ciphers ssl-export-ciphers ssl-null-ciphers ssl-only-weak-ciphers ssl-static-key-ciphers ssl-weak-message-authentication-code-algorithms rc4-cve-2013-2566 ssl-cve-2016-2183-sweet32 tls-dhe-export-ciphers-cve-2015-4000].freeze
 
     # Accepts an XML node from Nokogiri::XML.
     def initialize(xml_node)


### PR DESCRIPTION
### Summary
If ciphers are not wrapped in code blocks, they trigger the screenshot validator and can cause export errors. This PR expands the code block wrapping cipher coverage to include this plugin_id: 
* `ssl-weak-message-authentication-code-algorithms`

### Copyright assignment
> I assign all rights, including copyright, to any future Dradis work by myself to Security Roots.
