### PR TITLE
Fix fingerprints field for full_node template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
+v4.10.0 (XXX 2023)
+  - Fix fingerprints field for the full_node template
+
 v4.9.0 (June 2023)
   - Parse inline code, not just code blocks
   - Wrap ciphers in the `ssl-weak-message-authentication-code-algorithms` finding
-  - Fix fingerprints field for the full_node template
 
 v4.8.0 (April 2023)
   - No changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 v4.X.X (XXXX 2023)
   - Parse inline code, not just code blocks
   - Wrap ciphers in the `ssl-weak-message-authentication-code-algorithms` finding
+  - Fix fingerprints field for the full_node template
 
 v4.8.0 (April 2023)
   - No changes

--- a/lib/dradis/plugins/nexpose/gem_version.rb
+++ b/lib/dradis/plugins/nexpose/gem_version.rb
@@ -8,11 +8,11 @@ module Dradis
 
       module VERSION
         MAJOR = 4
-        MINOR = 9
+        MINOR = 10
         TINY = 0
         PRE = nil
 
-        STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")
+        STRING = [MAJOR, MINOR, TINY, PRE].compact.join('.')
       end
     end
   end

--- a/lib/nexpose/node.rb
+++ b/lib/nexpose/node.rb
@@ -43,10 +43,9 @@ module Nexpose
       @xml.xpath('./endpoints/endpoint').collect { |xml_endpoint| Endpoint.new(xml_endpoint) }
     end
 
-
     # This allows external callers (and specs) to check for implemented
     # properties
-    def respond_to?(method, include_private=false)
+    def respond_to?(method, include_private = false)
       return true if supported_tags.include?(method.to_sym)
       super
     end
@@ -58,7 +57,6 @@ module Nexpose
     # attribute, simple descendent or collection that it maps to in the XML
     # tree.
     def method_missing(method, *args)
-
       # We could remove this check and return nil for any non-recognized tag.
       # The problem would be that it would make tricky to debug problems with
       # typos. For instance: <>.potr would return nil instead of raising an
@@ -84,7 +82,7 @@ module Nexpose
 
       # Finally the enumerations: names
       if method_name == 'names'
-        @xml.xpath("./names/name").collect(&:text)
+        @xml.xpath('./names/name').collect(&:text)
 
       elsif ['fingerprints', 'software'].include?(method_name)
 
@@ -95,9 +93,9 @@ module Nexpose
 
         @xml.xpath(xpath_selector).collect do |xml_os|
           Hash[
-            xml_os.attributes.collect do |name, xml_attribute|
+            xml_os.attributes.filter_map do |name, xml_attribute|
               next if name == 'arch'
-              [name.sub(/-/,'_').to_sym, xml_attribute.value]
+              [name.sub(/-/ , '_').to_sym, xml_attribute.value]
             end
           ]
         end

--- a/lib/nexpose/node.rb
+++ b/lib/nexpose/node.rb
@@ -93,8 +93,7 @@ module Nexpose
 
         @xml.xpath(xpath_selector).collect do |xml_os|
           Hash[
-            xml_os.attributes.filter_map do |name, xml_attribute|
-              next if name == 'arch'
+            xml_os.attributes.collect do |name, xml_attribute|
               [name.sub(/-/ , '_').to_sym, xml_attribute.value]
             end
           ]

--- a/spec/fixtures/files/full.xml
+++ b/spec/fixtures/files/full.xml
@@ -9,7 +9,7 @@
         <name>localhost:5000</name>
       </names>
       <fingerprints>
-        <os certainty="0.80" family="IOS" product="IOS" vendor="Cisco"/>
+        <os certainty="0.80" family="IOS" product="IOS" vendor="Cisco" arch="x86_64"/>
       </fingerprints>
       <tests/>
       <endpoints>

--- a/spec/nexpose_upload_spec.rb
+++ b/spec/nexpose_upload_spec.rb
@@ -173,6 +173,7 @@ describe 'Nexpose upload plugin' do
     ts.set_template(template: 'full_node', content: "#[Fingerprints]#\n%node.fingerprints%\n")
     result = ts.process_template(data: doc.at_xpath('//nodes/node'), template: 'full_node')
 
-    expect(result).to include('| 0.80 | IOS | IOS | Cisco |')
+    expect(result).to include('|_. certainty |_. family |_. product |_. vendor |_. arch |')
+    expect(result).to include('| 0.80 | IOS | IOS | Cisco | x86_64 |')
   end
 end

--- a/spec/nexpose_upload_spec.rb
+++ b/spec/nexpose_upload_spec.rb
@@ -1,170 +1,178 @@
-require 'spec_helper'
+require 'rails_helper'
 require 'ostruct'
 
 describe 'Nexpose upload plugin' do
-  before(:each) do
-    # Stub template service
-    templates_dir = File.expand_path('../../templates', __FILE__)
-    expect_any_instance_of(Dradis::Plugins::TemplateService)
-    .to receive(:default_templates_dir).and_return(templates_dir)
-
-    # Init services
-    plugin = Dradis::Plugins::Nexpose
-
-    @content_service = Dradis::Plugins::ContentService::Base.new(
-      logger: Logger.new(STDOUT),
-      plugin: plugin
-    )
-
-    @importer = plugin::Importer.new(
-      content_service: @content_service,
-    )
-
-    # Stub dradis-plugins methods
-    #
-    # They return their argument hashes as objects mimicking
-    # Nodes, Issues, etc
-    allow(@content_service).to receive(:create_node) do |args|
-      OpenStruct.new(args)
-    end
-    allow(@content_service).to receive(:create_note) do |args|
-      OpenStruct.new(args)
-    end
-    allow(@content_service).to receive(:create_issue) do |args|
-      OpenStruct.new(args)
-    end
-    allow(@content_service).to receive(:create_evidence) do |args|
-      OpenStruct.new(args)
-    end
+  before do
+    @fixtures_dir = File.expand_path('../fixtures/files/', __FILE__)
   end
 
-  describe "Importer: Simple" do
-    it "creates nodes, issues, notes and an evidences as needed" do
+  describe 'importer' do
+    before(:each) do
+      # Stub template service
+      templates_dir = File.expand_path('../../templates', __FILE__)
+      expect_any_instance_of(Dradis::Plugins::TemplateService)
+        .to receive(:default_templates_dir).and_return(templates_dir)
 
-      expect(@content_service).to receive(:create_node).with(hash_including label: '1.1.1.1', type: :host).once
+      # Init services
+      plugin = Dradis::Plugins::Nexpose
 
-      expect(@content_service).to receive(:create_note) do |args|
-        expect(args[:text]).to include("Host Description : Linux 2.6.9-89.ELsmp")
-        expect(args[:text]).to include("Scanner Fingerprint certainty : 0.80")
-        expect(args[:node].label).to eq("1.1.1.1")
-      end.once
+      @content_service = Dradis::Plugins::ContentService::Base.new(
+        logger: Logger.new(STDOUT),
+        plugin: plugin
+      )
 
-      expect(@content_service).to receive(:create_node) do |args|
-        expect(args[:label]).to eq('Generic Findings')
-        expect(args[:parent].label).to eq("1.1.1.1")
-        OpenStruct.new(args)
-      end.once
+      @importer = plugin::Importer.new(
+        content_service: @content_service,
+      )
 
-      expect(@content_service).to receive(:create_node) do |args|
-        expect(args[:label]).to eq('udp-000')
-        expect(args[:parent].label).to eq("1.1.1.1")
-        OpenStruct.new(args)
-      end.once
-
-      expect(@content_service).to receive(:create_note) do |args|
-        expect(args[:text]).to include("#[Id]#\nntpd-crypto")
-        expect(args[:text]).to include("#[host]#\n1.1.1.1")
-        expect(args[:node].label).to eq("udp-000")
-      end.once
-
-      expect(@content_service).to receive(:create_note) do |args|
-        expect(args[:text]).to include("#[Id]#\nntp-clock-radio")
-        expect(args[:text]).to include("#[host]#\n1.1.1.1")
-        expect(args[:node].label).to eq("udp-000")
-      end.once
-
-      @importer.import(file: 'spec/fixtures/files/simple.xml')
-    end
-  end
-
-  describe "Importer: Full" do
-    it "creates nodes, issues, notes and an evidences as needed" do
-      expect(@content_service).to receive(:create_node).with(hash_including label: "Nexpose Scan Summary").once
-      expect(@content_service).to receive(:create_note) do |args|
-        expect(args[:text]).to include("#[Title]#\nUSDA_Internal (4)")
-        expect(args[:node].label).to eq("Nexpose Scan Summary")
-      end.once
-
-      expect(@content_service).to receive(:create_node).with(
-        hash_including label: "1.1.1.1", type: :host
-      ).twice
-
-      expect(@content_service).to receive(:create_note) do |args|
-        expect(args[:text]).to include("#[Title]#\n1.1.1.1")
-        expect(args[:node].label).to eq("1.1.1.1")
-      end.once
-
-      expect(@content_service).to receive(:create_note) do |args|
-        expect(args[:text]).to include("#[Title]#\nService name: NTP")
-        expect(args[:node].label).to eq("1.1.1.1")
-      end.once
-
-      expect(@content_service).to receive(:create_note) do |args|
-        expect(args[:text]).to include("#[Title]#\nService name: SNMP")
-        expect(args[:node].label).to eq("1.1.1.1")
-      end.once
-
-      expect(@content_service).to receive(:create_issue) do |args|
-        expect(args[:text]).to include("#[Title]#\nApache HTTPD: error responses can expose cookies (CVE-2012-0053)")
-        expect(args[:id]).to eq("ntp-clock-variables-disclosure")
-        OpenStruct.new(args)
-      end.once
-
-      expect(@content_service).to receive(:create_issue) do |args|
-        expect(args[:text]).to include("#[Title]#\nApache HTTPD: ETag Inode Information Leakage (CVE-2003-1418)")
-        expect(args[:id]).to eq("ntp-clock-variables-disclosure")
-        OpenStruct.new(args)
-      end.once
-
-      expect(@content_service).to receive(:create_evidence) do |args|
-        expect(args[:content]).to include("#[ID]#\nntp-clock-variables-disclosure\n\n")
-        expect(args[:issue].id).to eq("ntp-clock-variables-disclosure")
-        expect(args[:node].label).to eq("1.1.1.1")
-      end.once
-
-      allow_any_instance_of(OpenStruct).to receive(:respond_to?).with(:properties).and_return(true)
-      allow_any_instance_of(OpenStruct).to receive(:set_service).and_return(true)
-
-      expect_any_instance_of(OpenStruct).to receive(:set_property).with(:hostname, ['localhost:5000'])
-      expect_any_instance_of(OpenStruct).to receive(:set_property).with(:ip, '1.1.1.1')
-      expect_any_instance_of(OpenStruct).to receive(:set_property).with(:os, [])
-      expect_any_instance_of(OpenStruct).to receive(:set_property).with(:risk_score, '0.0')
-
-      @importer.import(file: 'spec/fixtures/files/full.xml')
-    end
-
-    it "wraps ciphers inside ssl issues in code blocks" do
-      expect(@content_service).to receive(:create_issue) do |args|
-        expect(args[:text]).to include("bc. ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256")
-        OpenStruct.new(args)
-      end.once
-
-      @importer.import(file: 'spec/fixtures/files/ssl.xml')
-    end
-
-    # Regression test for github.com/dradis/dradis-nexpose/issues/1
-    it "populates solutions regardless they are wrapped in paragraphs or lists" do
-      expect(@content_service).to receive(:create_issue) do |args|
-        expect(args[:text]).to include("#[Solution]#\n\nApache HTTPD >= 2.0 and < 2.0.65")
-        OpenStruct.new(args)
-      end.once
-
-      expect(@content_service).to receive(:create_issue) do |args|
-        expect(args[:text]).to include("#[Solution]#\n")
-        expect(args[:text]).to include("You can remove inode information from the ETag header")
-        OpenStruct.new(args)
-      end.once
-
-      @importer.import(file: 'spec/fixtures/files/full.xml')
-    end
-
-    it "transforms html entities (&lt; and &gt;)" do
-      expect(@content_service).to receive(:create_issue) do |args|
-        expect(args[:text]).to include("#[Solution]#\n\nApache HTTPD >= 2.0 and < 2.0.65")
+      # Stub dradis-plugins methods
+      #
+      # They return their argument hashes as objects mimicking
+      # Nodes, Issues, etc
+      allow(@content_service).to receive(:create_node) do |args|
         OpenStruct.new(args)
       end
-
-      @importer.import(file: 'spec/fixtures/files/full.xml')
+      allow(@content_service).to receive(:create_note) do |args|
+        OpenStruct.new(args)
+      end
+      allow(@content_service).to receive(:create_issue) do |args|
+        OpenStruct.new(args)
+      end
+      allow(@content_service).to receive(:create_evidence) do |args|
+        OpenStruct.new(args)
+      end
     end
+
+    describe 'Importer: Simple' do
+      it 'creates nodes, issues, notes and an evidences as needed' do
+
+        expect(@content_service).to receive(:create_node).with(hash_including label: '1.1.1.1', type: :host).once
+
+        expect(@content_service).to receive(:create_note) do |args|
+          expect(args[:text]).to include('Host Description : Linux 2.6.9-89.ELsmp')
+          expect(args[:text]).to include('Scanner Fingerprint certainty : 0.80')
+          expect(args[:node].label).to eq('1.1.1.1')
+        end.once
+
+        expect(@content_service).to receive(:create_node) do |args|
+          expect(args[:label]).to eq('Generic Findings')
+          expect(args[:parent].label).to eq('1.1.1.1')
+          OpenStruct.new(args)
+        end.once
+
+        expect(@content_service).to receive(:create_node) do |args|
+          expect(args[:label]).to eq('udp-000')
+          expect(args[:parent].label).to eq('1.1.1.1')
+          OpenStruct.new(args)
+        end.once
+
+        expect(@content_service).to receive(:create_note) do |args|
+          expect(args[:text]).to include("#[Id]#\nntpd-crypto")
+          expect(args[:text]).to include("#[host]#\n1.1.1.1")
+          expect(args[:node].label).to eq('udp-000')
+        end.once
+
+        expect(@content_service).to receive(:create_note) do |args|
+          expect(args[:text]).to include("#[Id]#\nntp-clock-radio")
+          expect(args[:text]).to include("#[host]#\n1.1.1.1")
+          expect(args[:node].label).to eq('udp-000')
+        end.once
+
+        @importer.import(file: @fixtures_dir + '/simple.xml')
+      end
+    end
+
+    describe 'Importer: Full' do
+      it 'creates nodes, issues, notes and an evidences as needed' do
+        expect(@content_service).to receive(:create_node).with(hash_including label: 'Nexpose Scan Summary').once
+        expect(@content_service).to receive(:create_note) do |args|
+          expect(args[:text]).to include("#[Title]#\nUSDA_Internal (4)")
+          expect(args[:node].label).to eq('Nexpose Scan Summary')
+        end.once
+
+        expect(@content_service).to receive(:create_node).with(
+          hash_including label: '1.1.1.1', type: :host
+        ).twice
+
+        expect(@content_service).to receive(:create_note) do |args|
+          expect(args[:text]).to include("#[Title]#\n1.1.1.1")
+          expect(args[:node].label).to eq('1.1.1.1')
+        end.once
+
+        expect(@content_service).to receive(:create_note) do |args|
+          expect(args[:text]).to include("#[Title]#\nService name: NTP")
+          expect(args[:node].label).to eq('1.1.1.1')
+        end.once
+
+        expect(@content_service).to receive(:create_note) do |args|
+          expect(args[:text]).to include("#[Title]#\nService name: SNMP")
+          expect(args[:node].label).to eq('1.1.1.1')
+        end.once
+
+        expect(@content_service).to receive(:create_issue) do |args|
+          expect(args[:text]).to include("#[Title]#\nApache HTTPD: error responses can expose cookies (CVE-2012-0053)")
+          expect(args[:id]).to eq('ntp-clock-variables-disclosure')
+          OpenStruct.new(args)
+        end.once
+
+        expect(@content_service).to receive(:create_issue) do |args|
+          expect(args[:text]).to include("#[Title]#\nApache HTTPD: ETag Inode Information Leakage (CVE-2003-1418)")
+          expect(args[:id]).to eq('ntp-clock-variables-disclosure')
+          OpenStruct.new(args)
+        end.once
+
+        expect(@content_service).to receive(:create_evidence) do |args|
+          expect(args[:content]).to include("#[ID]#\nntp-clock-variables-disclosure\n\n")
+          expect(args[:issue].id).to eq('ntp-clock-variables-disclosure')
+          expect(args[:node].label).to eq('1.1.1.1')
+        end.once
+
+        @importer.import(file: @fixtures_dir + '/full.xml')
+      end
+
+      it 'wraps ciphers inside ssl issues in code blocks' do
+        expect(@content_service).to receive(:create_issue) do |args|
+          expect(args[:text]).to include('bc. ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256')
+          OpenStruct.new(args)
+        end.once
+
+        @importer.import(file: @fixtures_dir + '/ssl.xml')
+      end
+
+      # Regression test for github.com/dradis/dradis-nexpose/issues/1
+      it 'populates solutions regardless they are wrapped in paragraphs or lists' do
+        expect(@content_service).to receive(:create_issue) do |args|
+          expect(args[:text]).to include("#[Solution]#\n\nApache HTTPD >= 2.0 and < 2.0.65")
+          OpenStruct.new(args)
+        end.once
+
+        expect(@content_service).to receive(:create_issue) do |args|
+          expect(args[:text]).to include("#[Solution]#\n")
+          expect(args[:text]).to include('You can remove inode information from the ETag header')
+          OpenStruct.new(args)
+        end.once
+
+        @importer.import(file: @fixtures_dir + '/full.xml')
+      end
+
+      it 'transforms html entities (&lt; and &gt;)' do
+        expect(@content_service).to receive(:create_issue) do |args|
+          expect(args[:text]).to include("#[Solution]#\n\nApache HTTPD >= 2.0 and < 2.0.65")
+          OpenStruct.new(args)
+        end
+
+        @importer.import(file: @fixtures_dir + '/full.xml')
+      end
+    end
+  end
+
+  it 'parses the fingerprints field' do
+    doc = Nokogiri::XML(File.read(@fixtures_dir + '/full.xml'))
+
+    ts = Dradis::Plugins::TemplateService.new(plugin: Dradis::Plugins::Nexpose)
+    ts.set_template(template: 'full_node', content: "#[Fingerprints]#\n%node.fingerprints%\n")
+    result = ts.process_template(data: doc.at_xpath('//nodes/node'), template: 'full_node')
+
+    expect(result).to include('| 0.80 | IOS | IOS | Cisco |')
   end
 end


### PR DESCRIPTION
### Spec
The logic around the handling of the node's `fingerprints` field does not account for having `arch` in the xml
```
<os ... arch="x86_64"/>
```

**Proposed solution**
Use `filter_map` [around this line](https://github.com/dradis/dradis-nexpose/blob/main/lib/nexpose/node.rb#L98) to properly remove the nil from the array when initializing the Hash.


### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

Thanks for contributing to Dradis!


### Copyright assignment

Collaboration is difficult with commercial closed source but we want
to keep as much of the OSS ethos as possible available to users
who want to fix it themselves.

In order to unambiguously own and sell Dradis Framework commercial
products, we must have the copyright associated with the entire
codebase. Any code you create which is merged must be owned by us.
That's not us trying to be a jerks, that's just the way it works.

Please review the [CONTRIBUTING.md](https://github.com/dradis/dradis-ce/blob/master/CONTRIBUTING.md)
file for the details.

You can delete this section, but the following sentence needs to
remain in the PR's description:

> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.
