### PR TITLE
Parse code tags as inline code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 v4.X.X (XXXX 2023)
+  - Parse code tags as inline code, not just paragraph preformat tags
+  
+v4.9.0 (June 2023)
   - Parse inline code, not just code blocks
   - Wrap ciphers in the `ssl-weak-message-authentication-code-algorithms` finding
 

--- a/lib/dradis/plugins/nexpose/gem_version.rb
+++ b/lib/dradis/plugins/nexpose/gem_version.rb
@@ -9,7 +9,7 @@ module Dradis
       module VERSION
         MAJOR = 4
         MINOR = 9
-        TINY = 0
+        TINY = 1
         PRE = nil
 
         STRING = [MAJOR, MINOR, TINY, PRE].compact.join(".")

--- a/lib/nexpose/vulnerability.rb
+++ b/lib/nexpose/vulnerability.rb
@@ -120,6 +120,7 @@ module Nexpose
         text = $1
         text[/\n/] ? "\nbc.. #{ text }\n\np. " : "@#{text}@"
       end
+      result.gsub!(/<code>(.*?)<\/code>/){"@#{ $1 }@"}
       result.gsub!(/<Paragraph>(.*?)<\/Paragraph>/m){|m| "#{ $1 }\n"}
       result.gsub!(/<Paragraph>|<\/Paragraph>/, '')
       result.gsub!(/<UnorderedList(.*?)>(.*?)<\/UnorderedList>/m){|m| "#{ $2 }"}


### PR DESCRIPTION
### Summary

Nexpose usually uses `<Paragraph preformat="true">` tags for code blocks or inline code. Recently, a user sent us a file that contained 3 instances of `<code></code>` tags. This PR updates our Nexpose import plugin to parse those `<code>` tags as inline code to prevent exporting a Word report that cannot be opened. 

### Copyright assignment

> I assign all rights, including copyright, to any future Dradis work by myself to Security Roots.