### PR TITLE
Add node_test to evidence as an array to match the way we handle service_tests

### DIFF
--- a/lib/dradis/plugins/nexpose/formats/full.rb
+++ b/lib/dradis/plugins/nexpose/formats/full.rb
@@ -58,7 +58,8 @@ module Dradis::Plugins::Nexpose::Formats
             xml_vuln.last_element_child.add_child("<host>#{nexpose_node.address}</host>")
           end
 
-          evidence[test_id][nexpose_node.address] = node_test
+          evidence[test_id][nexpose_node.address] ||= []
+          evidence[test_id][nexpose_node.address] << node_test
         end
 
         nexpose_node.endpoints.each do |endpoint|


### PR DESCRIPTION
### Summary
We recently updated the full importer to be able to create multiple evidence under the same node when they have the same test_id. We did this by adding each of them as an array under `evidence[test_id][nexpose_node.address]`. 

We didn't make this update to `node_test`, so it isn't an array, but a hash. This causes an error when we loop through on L150. 

The change in this PR adds `node_test` to `evidence[test_id][nexpose_node.address]` as an array instead of a hash to match the way we handle service_test on L110-111


> I assign all rights, including copyright, to any future Dradis
> work by myself to Security Roots.
